### PR TITLE
fix(ui): Prevent virt_text from leaking onto the next line

### DIFF
--- a/lua/gha-pin/cache.lua
+++ b/lua/gha-pin/cache.lua
@@ -109,74 +109,59 @@ local function save_once(cache, cb)
     return
   end
 
-  local dir = cache_dir()
-
-  -- Ensure directory exists (async mkdir)
-  fs.fs_mkdir(dir, 448, function(mkdir_err)
-    if mkdir_err and mkdir_err:match("EEXIST") == nil then
-      schedule_notify(
-        ("gha-pin.nvim: Failed to create cache directory: %s"):format(tostring(mkdir_err)),
-        vim.log.levels.WARN
-      )
+  -- Write to temporary file first (atomic write pattern). The cache
+  -- directory is created in `M.save` on the main loop, so we do not
+  -- touch the filesystem synchronously from here (this function can be
+  -- re-entered from a libuv callback during queue drain, which is a
+  -- fast event context where `vim.fn.*` calls are disallowed).
+  local tmp_path = path .. ".tmp"
+  fs.fs_open(tmp_path, "w", 438, function(open_err, fd)
+    if open_err or not fd then
+      schedule_notify(("gha-pin.nvim: Failed to open cache file: %s"):format(tostring(open_err)), vim.log.levels.WARN)
       if cb then
-        cb(false, tostring(mkdir_err))
+        cb(false, tostring(open_err))
       end
       return
     end
 
-    -- Write to temporary file first (atomic write pattern)
-    local tmp_path = path .. ".tmp"
-    fs.fs_open(tmp_path, "w", 438, function(open_err, fd)
-      if open_err or not fd then
-        schedule_notify(("gha-pin.nvim: Failed to open cache file: %s"):format(tostring(open_err)), vim.log.levels.WARN)
-        if cb then
-          cb(false, tostring(open_err))
-        end
+    fs.fs_write(fd, encoded, -1, function(write_err)
+      if write_err then
+        fs.fs_close(fd, function()
+          schedule_notify(("gha-pin.nvim: Failed to write cache: %s"):format(tostring(write_err)), vim.log.levels.WARN)
+          if cb then
+            cb(false, tostring(write_err))
+          end
+        end)
         return
       end
 
-      fs.fs_write(fd, encoded, -1, function(write_err)
-        if write_err then
-          fs.fs_close(fd, function()
-            schedule_notify(
-              ("gha-pin.nvim: Failed to write cache: %s"):format(tostring(write_err)),
-              vim.log.levels.WARN
-            )
-            if cb then
-              cb(false, tostring(write_err))
-            end
-          end)
+      fs.fs_close(fd, function(close_err)
+        if close_err then
+          schedule_notify(
+            ("gha-pin.nvim: Failed to close cache file: %s"):format(tostring(close_err)),
+            vim.log.levels.WARN
+          )
+          if cb then
+            cb(false, tostring(close_err))
+          end
           return
         end
 
-        fs.fs_close(fd, function(close_err)
-          if close_err then
+        -- Atomic rename from temp to actual path
+        fs.fs_rename(tmp_path, path, function(rename_err)
+          if rename_err then
             schedule_notify(
-              ("gha-pin.nvim: Failed to close cache file: %s"):format(tostring(close_err)),
+              ("gha-pin.nvim: Failed to rename cache file: %s"):format(tostring(rename_err)),
               vim.log.levels.WARN
             )
             if cb then
-              cb(false, tostring(close_err))
+              cb(false, tostring(rename_err))
             end
             return
           end
-
-          -- Atomic rename from temp to actual path
-          fs.fs_rename(tmp_path, path, function(rename_err)
-            if rename_err then
-              schedule_notify(
-                ("gha-pin.nvim: Failed to rename cache file: %s"):format(tostring(rename_err)),
-                vim.log.levels.WARN
-              )
-              if cb then
-                cb(false, tostring(rename_err))
-              end
-              return
-            end
-            if cb then
-              cb(true)
-            end
-          end)
+          if cb then
+            cb(true)
+          end
         end)
       end)
     end)
@@ -215,6 +200,19 @@ end
 ---@param cache GhaPinCache
 ---@param cb? fun(ok: boolean, err?: string)
 function M.save(cache, cb)
+  -- Create the cache directory here on the main loop. `vim.uv.fs_mkdir`
+  -- is not recursive, and `vim.fn.mkdir` cannot be called from the
+  -- libuv callbacks that re-drive the queue, so doing it once up front
+  -- guarantees `save_once` only has to perform async writes.
+  local mkdir_ok, mkdir_err = pcall(vim.fn.mkdir, cache_dir(), "p")
+  if not mkdir_ok then
+    vim.notify(("gha-pin.nvim: Failed to create cache directory: %s"):format(tostring(mkdir_err)), vim.log.levels.WARN)
+    if cb then
+      cb(false, tostring(mkdir_err))
+    end
+    return
+  end
+
   save_queue.cache = cache
   save_queue.pending = true
   if cb then

--- a/lua/gha-pin/cache.lua
+++ b/lua/gha-pin/cache.lua
@@ -32,6 +32,17 @@ local function cache_file()
   return cache_dir() .. "/cache.json"
 end
 
+---@param msg string
+---@param level integer
+local function schedule_notify(msg, level)
+  -- `vim.notify` ultimately calls `nvim_echo`, which is disallowed in a fast
+  -- event context (e.g. libuv callbacks). Defer to the main loop so writes
+  -- triggered from `vim.uv.fs_*` callbacks do not crash on nightly Neovim.
+  vim.schedule(function()
+    vim.notify(msg, level)
+  end)
+end
+
 ---@param s string
 ---@return any
 local function json_decode(s)
@@ -103,7 +114,7 @@ local function save_once(cache, cb)
   -- Ensure directory exists (async mkdir)
   fs.fs_mkdir(dir, 448, function(mkdir_err)
     if mkdir_err and mkdir_err:match("EEXIST") == nil then
-      vim.notify(
+      schedule_notify(
         ("gha-pin.nvim: Failed to create cache directory: %s"):format(tostring(mkdir_err)),
         vim.log.levels.WARN
       )
@@ -117,7 +128,7 @@ local function save_once(cache, cb)
     local tmp_path = path .. ".tmp"
     fs.fs_open(tmp_path, "w", 438, function(open_err, fd)
       if open_err or not fd then
-        vim.notify(("gha-pin.nvim: Failed to open cache file: %s"):format(tostring(open_err)), vim.log.levels.WARN)
+        schedule_notify(("gha-pin.nvim: Failed to open cache file: %s"):format(tostring(open_err)), vim.log.levels.WARN)
         if cb then
           cb(false, tostring(open_err))
         end
@@ -127,7 +138,10 @@ local function save_once(cache, cb)
       fs.fs_write(fd, encoded, -1, function(write_err)
         if write_err then
           fs.fs_close(fd, function()
-            vim.notify(("gha-pin.nvim: Failed to write cache: %s"):format(tostring(write_err)), vim.log.levels.WARN)
+            schedule_notify(
+              ("gha-pin.nvim: Failed to write cache: %s"):format(tostring(write_err)),
+              vim.log.levels.WARN
+            )
             if cb then
               cb(false, tostring(write_err))
             end
@@ -137,7 +151,7 @@ local function save_once(cache, cb)
 
         fs.fs_close(fd, function(close_err)
           if close_err then
-            vim.notify(
+            schedule_notify(
               ("gha-pin.nvim: Failed to close cache file: %s"):format(tostring(close_err)),
               vim.log.levels.WARN
             )
@@ -150,7 +164,7 @@ local function save_once(cache, cb)
           -- Atomic rename from temp to actual path
           fs.fs_rename(tmp_path, path, function(rename_err)
             if rename_err then
-              vim.notify(
+              schedule_notify(
                 ("gha-pin.nvim: Failed to rename cache file: %s"):format(tostring(rename_err)),
                 vim.log.levels.WARN
               )

--- a/lua/gha-pin/ui.lua
+++ b/lua/gha-pin/ui.lua
@@ -23,12 +23,24 @@ function M.set_virtual_text(bufnr, items, enabled)
   end
 
   M.clear(bufnr)
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    return
+  end
+  local line_count = vim.api.nvim_buf_line_count(bufnr)
   for _, it in ipairs(items) do
-    if it.text and it.text ~= "" then
+    if it.text and it.text ~= "" and it.lnum >= 0 and it.lnum < line_count then
+      local line = vim.api.nvim_buf_get_lines(bufnr, it.lnum, it.lnum + 1, false)[1] or ""
+      -- Span the extmark across the whole line and mark it `invalidate`-able
+      -- so that deleting the `uses:` line drops the extmark instead of
+      -- pulling it onto the following line (e.g. a `with:` line below).
       pcall(vim.api.nvim_buf_set_extmark, bufnr, M.ns, it.lnum, 0, {
+        end_row = it.lnum,
+        end_col = #line,
         virt_text = { { it.text, "Comment" } },
         virt_text_pos = "eol",
         hl_mode = "combine",
+        invalidate = true,
+        undo_restore = false,
       })
     end
   end

--- a/tests/test_github.lua
+++ b/tests/test_github.lua
@@ -497,8 +497,8 @@ T["resolve_latest: annotated tag within cooldown returns empty SHA"] = function(
 end
 
 T["resolve_latest: annotated tag past cooldown returns actual SHA"] = function()
-  local tag_sha = hex40("g")
-  local commit_sha = hex40("h")
+  local tag_sha = hex40("0")
+  local commit_sha = hex40("1")
   local cfg = { api_base_url = "https://api.github.com", prefer_gh = false, token_env = "GITHUB_TOKEN" }
 
   -- Mock timestamp_age_seconds to return a value past cooldown period


### PR DESCRIPTION
## Summary

- Anchor the `# Latest: ...` virtual text across the full line range and mark the extmark `invalidate`-able so deleting the `uses:` line drops the annotation instead of relocating it onto the next line.
- Make the async cache save path safe under Neovim nightly's fast-event-context rules by deferring notifications to the main loop.
- Fix the cooldown test for annotated tags so it constructs SHAs from valid hex characters and exercises the resolver instead of crashing on a `nil` result.
- Create the cache directory once on the main loop so a fresh checkout no longer hits `ENOENT`, and so the queue-drain re-entry from libuv callbacks stays in async-only code.

## Changes

- b40bc32 : fix: prevent virt_text from leaking onto the next line
  - Anchor the extmark with `end_row` / `end_col` spanning the whole line, plus `invalidate = true` and `undo_restore = false`, so the annotation is dropped together with its `uses:` line instead of drifting onto a sibling block.
  - Guard against invalid buffers and out-of-range `lnum` values when placing the extmark.
- 91655f1 : fix(cache): defer vim.notify to main loop from libuv callbacks
  - Wrap every save-path notification in a `schedule_notify` helper that hops back to the main loop, so `vim.uv.fs_*` error branches no longer trip `E5560: nvim_echo must not be called in a fast event context` on nightly.
- 0f660f5 : test(github): use valid hex characters for annotated tag SHAs
  - Replace the `g`/`h` placeholder bytes in the annotated-tag cooldown fixture with valid hex digits so the new `is_hex40` guard accepts them and the resolver actually returns a result for the assertion.
- 5015971 : fix(cache): create cache directory on the main loop
  - Hoist `vim.fn.mkdir(dir, "p")` into `M.save`, which is always entered from the main loop, so the cache directory (including the `stdpath('cache')` parent) is created up front on a fresh checkout.
  - Drop the in-callback mkdir from `save_once`; the function now only performs async I/O, which keeps it safe when the queue drains from the `fs_rename` callback (a fast event context that disallows `vim.fn.*`).